### PR TITLE
Update to maintained node_pcap

### DIFF
--- a/observers/observer-arp.js
+++ b/observers/observer-arp.js
@@ -3,7 +3,7 @@
 var EventEmitter = require('events').EventEmitter
   , arpa         = require('arp-a')
   , os           = require('os')
-  , pcap2        = require('pcap2')
+  , pcap         = require('pcap')
   , underscore   = require('underscore')
   , util         = require('util')
 
@@ -141,8 +141,8 @@ var IFace = function (arp, ifname) {
   var self = this
 
   try {
-    self.session = new pcap2.Session(ifname, { filter: 'arp' }).on('packet', function(raw) {
-      var frame = pcap2.decode.packet(raw)
+    self.session = new pcap.Session(ifname, { filter: 'arp' }).on('packet', function(raw) {
+      var frame = pcap.decode.packet(raw)
         , packet = frame && frame.link && frame.link.arp
 
       if ((!packet)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
-  , "pcap2"                      : "git+https://github.com/node-pcap/node_pcap.git"
+  , "pcap"                      : "git+https://github.com/node-pcap/node_pcap.git"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
-  , "pcap2"                      : "git+https://github.com/mkormendy/node-pcap.git"
+  , "pcap2"                      : "git+https://github.com/node-pcap/node_pcap.git"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
+  , "pcap2"                      : "3.0.4"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
-  , "pcap2"                      : "git://github.com/mkormendy/node-pcap.git"
+  , "pcap2"                      : "git+https://github.com/mkormendy/node-pcap.git"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
-  , "pcap2"                      : "3.0.4"
+  , "pcap2"                      : "git://github.com/mkormendy/node-pcap.git"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   , "bonjour"                    : "3.5.0"
   , "glob"                       : "^7.0.6"
   , "multicast-dns"              : "^6.0.1"
-  , "pcap2"                      : "3.0.4"
   , "pluralize"                  : "3.0.0"
   , "snmp-native"                : "1.0.18"
   , "underscore"                 : "1.8.3"


### PR DESCRIPTION
Might want to use the recently maintained original node_pcap package instead of @andygreenegrass's which is unmaintained and doesn't have the socketwatcher fixes like the original now does.